### PR TITLE
fix: allow multiple registries per organization

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web",
-    "version": "0.11.5",
+    "version": "0.11.6",
     "type": "module",
     "private": true,
     "scripts": {

--- a/packages/db/prisma/migrations/20251211125015_allow_multiple_registries_on_organization/migration.sql
+++ b/packages/db/prisma/migrations/20251211125015_allow_multiple_registries_on_organization/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `registryId` on the `organization` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "organization" DROP CONSTRAINT "organization_registryId_fkey";
+
+-- AlterTable
+ALTER TABLE "organization" DROP COLUMN "registryId";
+
+-- CreateTable
+CREATE TABLE "_OrganizationToRegistry" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_OrganizationToRegistry_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_OrganizationToRegistry_B_index" ON "_OrganizationToRegistry"("B");
+
+-- AddForeignKey
+ALTER TABLE "_OrganizationToRegistry" ADD CONSTRAINT "_OrganizationToRegistry_A_fkey" FOREIGN KEY ("A") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_OrganizationToRegistry" ADD CONSTRAINT "_OrganizationToRegistry_B_fkey" FOREIGN KEY ("B") REFERENCES "Registry"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -129,8 +129,7 @@ model Organization {
     projects              Project[]
     servers               Server[]
     sshKeys               SSHKey[]
-    registries            Registry?              @relation(fields: [registryId], references: [id])
-    registryId            String?
+    registries            Registry[]
     notificationProviders NotificationProvider[]
     notifications         Notification[]
     storageDestinations   StorageDestination[]


### PR DESCRIPTION


- Updated `apps/web/package.json` version to `0.11.6`.
- Modified Prisma schema to enable support for multiple registries per organization.
- Added migration to drop `registryId` column, create a join table, and update relationships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organizations can now be associated with multiple registries, enabling greater flexibility in managing registry configurations and resources.

* **Chores**
  * Version bumped to 0.11.6.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->